### PR TITLE
Make setup/build scripts CMake generator-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Intermittent Computing Emulator
 ## Building ICEmu
 1. Checkout ICEmu
 2. Update all the sumbmodules: `git submodule update --init --recursive`
-3. Create a build directory and build:
-`mkdir build && cd build && cmake ../ && make`
-4. (optionally) Build arm code in `arm-code`:
-`cd arm-code && mkdir build && cd build && cmake ../ && make`
+3. Setup the common libraries:
+`./setup-lib.sh`
+4. (optionally) Build arm code:
+`./arm-code/build-gcc.sh` (or `build-clang.sh` if applicable)
 5. Run an elf binary in ICEmu (the memory layout in the config file must
    correspond to that of the device the .elf is created for).
 

--- a/arm-code/build-clang.sh
+++ b/arm-code/build-clang.sh
@@ -8,5 +8,5 @@ echo "Building ARM code using Clang"
 mkdir -p build-clang
 pushd build-clang
 ../cmake-clang.sh ../
-make
+cmake --build .
 popd

--- a/arm-code/build-gcc.sh
+++ b/arm-code/build-gcc.sh
@@ -8,5 +8,5 @@ echo "Building ARM code using GCC"
 mkdir -p build-gcc
 pushd build-gcc
 ../cmake-gcc.sh ../
-make
+cmake --build .
 popd

--- a/setup-lib.sh
+++ b/setup-lib.sh
@@ -3,30 +3,25 @@
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $BASE_DIR
 
+# If MAKEFLAGS was not explicitly set by the user, set it with the number of cores
+# in case the user makes use of the "Unix Makefiles" CMake generator
+if [ -z "$MAKEFLAGS" ]; then
+    export MAKEFLAGS="-j$(nproc)"
+fi
+
 pushd lib
 
 #git submodule update --init --recursive unicorn
-pushd unicorn
 echo "Build unicorn"
-# If a build already exists (avoid re-configure)
-if [ -d build ]; then
-    pushd build
-    make -j$(nproc)
-    popd
-else
-    mkdir build
-    pushd build
-    cmake ../
-    make -j$(nproc)
-    popd
+# Only configure if not done so yet
+if [ ! -d unicorn/build ]; then
+    cmake -S unicorn -B unicorn/build
 fi
-
-popd
+cmake --build unicorn/build
 
 #git submodule update --init --recursive capstone
-pushd capstone
 echo "Build capstone"
-./make.sh
-popd
+cmake -S capstone -B capstone/build -DCMAKE_BUILD_TYPE=Release
+cmake --build capstone/build
 
 popd


### PR DESCRIPTION
This lifts the constraint on the user to use Make and allows for more modern build executors such as Ninja to execute the build as well.

While Ninja by default applies maximal parallelism, Make does not.
We still set `MAKEFLAGS` to `-j$(nproc)` (if not set already) to mimic the previous behavior and not impose additional configuration requirements for users on platforms with Make being the default CMake generator.