### PR TITLE
Execute wrapped main binary through exec

### DIFF
--- a/bin/icemu
+++ b/bin/icemu
@@ -198,4 +198,4 @@ echo
 
 # Disable memory leak warnings (Unicorn has one, out of our control)
 export ASAN_OPTIONS=detect_leaks=0
-$cmd
+exec $cmd


### PR DESCRIPTION
This ensures no new PID is allocated and thus
makes it easier to keep track of the process.
Since it is the last statement in the bash script,
it is completely safe to use exec.